### PR TITLE
Valuation Improvements

### DIFF
--- a/source-code/risk-analysis/weighted-average-cost-of-capital.js
+++ b/source-code/risk-analysis/weighted-average-cost-of-capital.js
@@ -13,7 +13,7 @@ Input(
 
 $.when(
   get_income_statement_ltm(),
-  get_balance_sheet_statement_quarterly(),
+  get_balance_sheet_statement_quarterly('length:2'),
   get_profile(),
   get_treasury(),
   get_fx(),
@@ -52,7 +52,7 @@ $.when(
     
     // Weights
     var totalDebt = response.balance_ltm['shortTermDebt'] + response.balance_ltm['longTermDebt'];
-    var marketCap = response.profile['mktCap']; // get the market cap in reports currency
+    var marketCap = response.profile['price'] * response.income_ltm['weightedAverageShsOut'];
     
     var debtWeight = totalDebt / (marketCap + totalDebt);
     var equityWeight = marketCap / (marketCap + totalDebt);

--- a/source-code/valuations/discounted-free-cash-flow-multiple.js
+++ b/source-code/valuations/discounted-free-cash-flow-multiple.js
@@ -26,7 +26,7 @@ Input(
 $.when(
   get_income_statement(),
   get_income_statement_ltm(),
-  get_balance_sheet_statement_quarterly(),
+  get_balance_sheet_statement_quarterly('length:2'),
   get_cash_flow_statement(),
   get_cash_flow_statement_ltm(),
   get_profile(),
@@ -68,7 +68,7 @@ $.when(
     {
 		taxRate = 0;
     }
-    var marketCap = response.profile['mktCap'];
+    var marketCap = response.profile['price'] * response.income_ltm['weightedAverageShsOut'];
     
     var debtWeight = response.balance_ltm['totalDebt'] / (marketCap + response.balance_ltm['totalDebt']);
     var equityWeight = marketCap / (marketCap + response.balance_ltm['totalDebt']);

--- a/source-code/valuations/discounted-free-cash-flow-perpetuity.js
+++ b/source-code/valuations/discounted-free-cash-flow-perpetuity.js
@@ -25,7 +25,7 @@ Input(
 $.when(
   get_income_statement(),
   get_income_statement_ltm(),
-  get_balance_sheet_statement_quarterly(),
+  get_balance_sheet_statement_quarterly('length:2'),
   get_cash_flow_statement(),
   get_cash_flow_statement_ltm(),
   get_profile(),
@@ -72,7 +72,7 @@ $.when(
     {
 		taxRate = 0;
     }
-    var marketCap = response.profile['mktCap'];
+    var marketCap = response.profile['price'] * response.income_ltm['weightedAverageShsOut'];
     
     var debtWeight = response.balance_ltm['totalDebt'] / (marketCap + response.balance_ltm['totalDebt']);
     var equityWeight = marketCap / (marketCap + response.balance_ltm['totalDebt']);

--- a/source-code/valuations/simple-dividend-discount-model.js
+++ b/source-code/valuations/simple-dividend-discount-model.js
@@ -23,7 +23,7 @@ $.when(
   get_income_statement(),
   get_income_statement_ltm(),
   get_balance_sheet_statement(),
-  get_balance_sheet_statement_quarterly(),
+  get_balance_sheet_statement_quarterly('length:2'),
   get_cash_flow_statement(),
   get_cash_flow_statement_ltm(),
   get_profile(),

--- a/source-code/valuations/simple-excess-return-model.js
+++ b/source-code/valuations/simple-excess-return-model.js
@@ -23,7 +23,7 @@ $.when(
   get_income_statement(),
   get_income_statement_ltm(),
   get_balance_sheet_statement(),
-  get_balance_sheet_statement_quarterly(),
+  get_balance_sheet_statement_quarterly('length:2'),
   get_profile(),
   get_dividends_annual(),
   get_treasury(),

--- a/source-code/valuations/two-stage-dividend-discount-model.js
+++ b/source-code/valuations/two-stage-dividend-discount-model.js
@@ -26,7 +26,7 @@ $.when(
   get_income_statement(),
   get_income_statement_ltm(),
   get_balance_sheet_statement(),
-  get_balance_sheet_statement_quarterly(),
+  get_balance_sheet_statement_quarterly('length:2'),
   get_cash_flow_statement(),
   get_cash_flow_statement_ltm(),
   get_profile(),

--- a/source-code/valuations/two-stage-excess-return-model.js
+++ b/source-code/valuations/two-stage-excess-return-model.js
@@ -24,7 +24,7 @@ $.when(
   get_income_statement(),
   get_income_statement_ltm(),
   get_balance_sheet_statement(),
-  get_balance_sheet_statement_quarterly(),
+  get_balance_sheet_statement_quarterly('length:2'),
   get_profile(),
   get_dividends_annual(),
   get_treasury(),


### PR DESCRIPTION
All quarterly balance sheet history was not needed, so only the last two reports are fetched for improved speed.
get_balance_sheet_statement_quarterly() -> get_balance_sheet_statement_quarterly('length:2')

Market Capitalization was not calculated correctly for companies that have profile currency different from the report currency.
var marketCap = response.profile['price'] * response.income_ltm['weightedAverageShsOut'];