### PR TITLE
Update models to include new framework features

### DIFF
--- a/source-code/valuations/benjamin-grahams-number.py
+++ b/source-code/valuations/benjamin-grahams-number.py
@@ -20,7 +20,7 @@ Read more: [Using The Graham Number Correctly](https://www.grahamvalue.com/artic
 assumptions.init({
     "data": {
         "earnings_per_share": data.get("income:eps"),
-        "book_value_per_share": data.get("balance:totalStockholdersEquity") / data.get("income:weightedAverageShsOut"),
+        "book_value_per_share": data.get("balance:totalStockholdersEquity / income:weightedAverageShsOut"),
         "graham_multiplier": 22.5,
         "historical_years": 10
     }

--- a/source-code/valuations/discounted-future-market-cap.py
+++ b/source-code/valuations/discounted-future-market-cap.py
@@ -18,7 +18,7 @@ assumptions.init({
         "beta": data.get("profile:beta", default=1),
         "%risk_free_rate": data.get("treasury:year10"),
         "%market_premium": data.get("risk:totalEquityRiskPremium"),
-        "pe_ratio": data.get("quote:close") / data.get("income:eps"),
+        "pe_ratio": data.get("ratio:priceEarningsRatio"),
         "%revenue_growth_rate": None,
         "%net_income_margin": None,
         "historical_years": 10,
@@ -102,7 +102,7 @@ model.render_results([
     [discounted_future_market_cap, "Market capitalization discounted to present", "$"],
     [shares_outstanding, "Shares Outstanding", "#"],
     [data.get("income:eps"), "Earnings Per Share (EPS)", "$"],
-    [data.get("quote:close"), "Market Price", "$"],
+    [data.get("profile:price"), "Market Price", "$"],
     [data.get("ratio:priceEarningsRatio"), "Price to Earnings (PE) Ratio", "#"]
 ])
 

--- a/source-code/valuations/simple-excess-return-model.py
+++ b/source-code/valuations/simple-excess-return-model.py
@@ -137,13 +137,6 @@ model.render_table({
     }
 })
 
-# Prepare properties for table rendering
-properties = {
-    "title": "Historical data",
-    "number_format": "M",
-    "display_averages": True
-}
-
 # Historical Table
 model.render_table({
     "data": {
@@ -159,7 +152,11 @@ model.render_table({
     },
     "start": -assumptions.get('historical_years'),
     "end": 0,
-    "properties": properties
+    "properties": {
+        "title": "Historical data",
+        "number_format": "M",
+        "display_averages": True
+    }
 })
 
 assumptions.set_description({


### PR DESCRIPTION
### `%tax_rate` added as an assumption to the Weighted Average Cost of Capital formula

The assumption is now available in:
- [Weighted Average Cost of Capital](https://github.com/DiscountingCashFlows/Documentation/pull/29/files#diff-cc83af38542c1c2e89ee43863b1f18594d1266e9eccd7160cfb2718b27734f65)
- [Discounted Free Cash Flow - Exit Multiple](https://github.com/DiscountingCashFlows/Documentation/pull/29/files#diff-8e23eda5da01fcd2cfde321dbcc13f41f5cbe4d7d2249ccd249af42788de38ef)
- [Discounted Free Cash Flow - Perpetuity](https://github.com/DiscountingCashFlows/Documentation/pull/29/files#diff-c5fa726cf249b5761e2bd13a9f4a0201552a49b97d248d5bf4940eb15125f8fe)

### `data.get` now supports inline formulas

Previously, `data.get` could only retrieve a single data key at a time, meaning formulas had to be calculated manually, e.g.:

```python
data.get("income:interestExpense") / data.get("balance:totalDebt")
```

With this update, you can perform calculations directly within the data.get call:

```python
data.get("income:interestExpense / balance:totalDebt")
```